### PR TITLE
feat: コミット前の品質チェック用pre-commitフックの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,8 @@ next-env.d.ts
 
 /public/uploads
 
-# Playwright
+# E2E test
+/e2e-test-logs/
 /test-results/
 /playwright-report/
 /playwright/.cache/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# pre-commit hook for quality checks
+echo "🐱 Pre-commit checks starting..."
+
+# Run lint-staged for incremental checks
+npx lint-staged
+
+# Run full quality checks
+echo "📋 Running quality checks..."
+
+# 1. Lint check
+echo "🔍 Running lint..."
+npm run lint
+if [ $? -ne 0 ]; then
+  echo "❌ Lint check failed! Please fix lint errors before committing."
+  exit 1
+fi
+
+# 2. Type check
+echo "📝 Running type check..."
+npx tsc --noEmit
+if [ $? -ne 0 ]; then
+  echo "❌ Type check failed! Please fix type errors before committing."
+  exit 1
+fi
+
+# 3. Unit tests
+echo "🧪 Running unit tests..."
+npm test -- --watchAll=false
+if [ $? -ne 0 ]; then
+  echo "❌ Unit tests failed! Please fix failing tests before committing."
+  exit 1
+fi
+
+# 4. Security audit
+echo "🔒 Running security audit..."
+npm audit --audit-level=moderate
+if [ $? -ne 0 ]; then
+  echo "⚠️ Security audit found vulnerabilities! Please review and fix if possible."
+  # Note: Not blocking commit for audit issues, just warning
+fi
+
+# 5. E2E tests (full suite)
+echo "🌐 Running E2E tests (all browsers)..."
+npm run e2e
+if [ $? -ne 0 ]; then
+  echo "❌ E2E tests failed! Please fix failing E2E tests before committing."
+  exit 1
+fi
+
+echo "✅ All pre-commit checks passed! 🎉"

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/e2e/tests/workflows/complete-user-journey.spec.ts
+++ b/e2e/tests/workflows/complete-user-journey.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '../../fixtures/test-fixtures';
-import { NavigationHelper, FormHelper, ModalHelper, TableHelper, CrossBrowserHelper } from '../../helpers';
+import {
+  NavigationHelper,
+  FormHelper,
+  ModalHelper,
+  TableHelper,
+  CrossBrowserHelper,
+} from '../../helpers';
+import * as path from 'path';
 
 test.describe.configure({ mode: 'serial' }); // ワークフローテストは順次実行
 test.describe('@workflow Complete User Journey', () => {
@@ -43,7 +50,9 @@ test.describe('@workflow Complete User Journey', () => {
     await modal.waitForClose();
 
     // 機材が正常に登録されたことを確認
-    await expect(page.locator(`td:has-text("${uniqueEquipmentName}")`)).toBeVisible({ timeout: 10000 });
+    await expect(page.locator(`td:has-text("${uniqueEquipmentName}")`)).toBeVisible({
+      timeout: 10000,
+    });
 
     // 3. 新規素材登録
     await navigation.goToNewMaterialPage();
@@ -52,27 +61,33 @@ test.describe('@workflow Complete User Journey', () => {
     // 基本情報を入力（ユニークなタイトルを使用）
     const uniqueMaterialTitle = `E2E Test Forest Morning ${Date.now()}`;
     await form.fillByLabel('Title', uniqueMaterialTitle);
-    await form.fillTextareaByLabel('Memo', 'Beautiful morning sounds in the forest with bird songs and gentle wind through trees');
-    
+    await form.fillTextareaByLabel(
+      'Memo',
+      'Beautiful morning sounds in the forest with bird songs and gentle wind through trees',
+    );
+
     // 録音日時を設定（現在日時から1日前）
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
     const dateTimeString = yesterday.toISOString().slice(0, 16); // YYYY-MM-DDTHH:MM format
     await form.fillByLabel('Recorded At', dateTimeString);
-    
+
     // 位置情報を入力
     await form.fillByLabel('Latitude', '31.9077');
     await form.fillByLabel('Longitude', '131.4202');
     await form.fillByLabel('Location Name (Optional)', 'Miyazaki Forest Park, Japan');
-    
+
     // テスト用音声ファイルをアップロード
-    const testAudioPath = require('path').join(process.cwd(), 'e2e', 'fixtures', 'test-audio.wav');
+    const testAudioPath = path.join(process.cwd(), 'e2e', 'fixtures', 'test-audio.wav');
     const fileInput = page.locator('input[type="file"]');
     await fileInput.setInputFiles(testAudioPath);
-    
+
     // ファイルが選択されたことを確認
     await page.waitForTimeout(500); // ファイル選択の処理を待つ
-    const selectedFileText = await page.locator('p:has-text("Selected file:")').textContent().catch(() => '');
+    const selectedFileText = await page
+      .locator('p:has-text("Selected file:")')
+      .textContent()
+      .catch(() => '');
     if (selectedFileText && !selectedFileText.includes('test-audio.wav')) {
       console.error(`File not selected properly. Browser: ${crossBrowser.getBrowserName()}`);
     }
@@ -87,7 +102,7 @@ test.describe('@workflow Complete User Journey', () => {
     await form.fillByLabel('Sample Rate (Hz)', '48000');
     await form.fillByLabel('Bit Depth', '24');
     await form.fillByLabel('File Format', 'WAV');
-    
+
     // 評価を入力
     await form.fillByLabel('Rating (1-5)', '5');
 
@@ -99,93 +114,112 @@ test.describe('@workflow Complete User Journey', () => {
 
     // フォーム送信
     const submitButton = page.locator('button[type="submit"]:has-text("Save Material")');
-    
+
     // デバッグ用：フォーム送信前の状態を確認
     await expect(submitButton).toBeEnabled();
     await expect(submitButton).toBeVisible();
-    
+
     // ネットワークリクエストを監視
     const [request] = await Promise.all([
-      page.waitForRequest(req => req.url().includes('/api/materials') && req.method() === 'POST', { timeout: 10000 }).catch(() => null),
-      submitButton.click()
+      page
+        .waitForRequest((req) => req.url().includes('/api/materials') && req.method() === 'POST', {
+          timeout: 10000,
+        })
+        .catch(() => null),
+      submitButton.click(),
     ]);
-    
+
     if (!request) {
       // リクエストが送信されなかった場合、エラー情報を取得
-      const errorText = await page.locator('[role="alert"]').textContent().catch(() => 'No error message');
+      const errorText = await page
+        .locator('[role="alert"]')
+        .textContent()
+        .catch(() => 'No error message');
       console.error(`POST request to /api/materials was not sent. Error: ${errorText}`);
       console.error(`Browser: ${crossBrowser.getBrowserName()}`);
-      
+
       // フォームの状態を確認
-      const isSubmitting = await page.locator('button:has-text("Saving...")').isVisible().catch(() => false);
+      const isSubmitting = await page
+        .locator('button:has-text("Saving...")')
+        .isVisible()
+        .catch(() => false);
       console.error(`Form is submitting: ${isSubmitting}`);
     }
-    
+
     // リダイレクトを待つ（alertダイアログは表示されないため、直接遷移を待つ）
     await page.waitForURL('/materials', { timeout: 15000 });
-    
+
     // 素材一覧ページに遷移したことを確認
     await expect(page.locator('h1')).toHaveText('Materials');
 
     // WebKitでは素材一覧の読み込みに時間がかかることがあるため、
     // ページが完全に読み込まれるまで待機
     await page.waitForLoadState('networkidle');
-    
+
     // WebKitとFirefoxで特別な待機処理
     const browserName = crossBrowser.getBrowserName();
-    
+
     // Firefox/WebKitでは追加の待機が必要
     if (browserName === 'firefox' || browserName === 'webkit') {
       try {
         // API応答を待つか、データが表示されるかのいずれか早い方
         await Promise.race([
-          page.waitForResponse(response => 
-            response.url().includes('/api/materials') && response.status() === 200,
-            { timeout: 5000 }
+          page.waitForResponse(
+            (response) => response.url().includes('/api/materials') && response.status() === 200,
+            { timeout: 5000 },
           ),
-          page.waitForFunction(() => {
-            const rows = document.querySelectorAll('tbody tr');
-            return rows.length > 0;
-          }, { timeout: 5000 })
+          page.waitForFunction(
+            () => {
+              const rows = document.querySelectorAll('tbody tr');
+              return rows.length > 0;
+            },
+            { timeout: 5000 },
+          ),
         ]);
-      } catch (e) {
+      } catch {
         // タイムアウトの場合はページをリロードして再試行
         console.log('Initial data load timeout, reloading page...');
         await page.reload();
         await page.waitForLoadState('networkidle');
       }
     }
-    
+
     // データが読み込まれるまで待機
-    await page.waitForFunction(() => {
-      const rows = document.querySelectorAll('tbody tr');
-      return rows.length > 0;
-    }, { timeout: 10000 });
+    await page.waitForFunction(
+      () => {
+        const rows = document.querySelectorAll('tbody tr');
+        return rows.length > 0;
+      },
+      { timeout: 10000 },
+    );
 
     // 新しく作成した素材が表示されることを確認
     // まず素材テーブルが存在することを確認
     await crossBrowser.waitForElementVisible('tbody', { timeout: 15000 });
-    
+
     // WebKit/Firefoxでは追加の待機が必要
     if (browserName === 'webkit' || browserName === 'firefox') {
       // テーブルにデータが表示されるまで待機
-      await page.waitForFunction(() => {
-        const cells = document.querySelectorAll('tbody td');
-        return cells.length > 0;
-      }, { timeout: 15000 });
-      
+      await page.waitForFunction(
+        () => {
+          const cells = document.querySelectorAll('tbody td');
+          return cells.length > 0;
+        },
+        { timeout: 15000 },
+      );
+
       // 追加の安定化待機
       await page.waitForTimeout(1000);
     }
-    
+
     // 素材が表示されるまで待機（完全なタイトルで検索し、first()を使用）
     console.log(`Waiting for material: ${uniqueMaterialTitle}`);
-    
+
     // Firefox/WebKitでは追加の待機が必要な場合がある
     if (browserName === 'firefox' || browserName === 'webkit') {
       await page.waitForTimeout(2000);
     }
-    
+
     // 作成した素材を検索して確実に見つける
     // 素材が多い場合、ページネーションで見つからない可能性があるため、
     // タイトルフィルターを使用して検索
@@ -193,7 +227,7 @@ test.describe('@workflow Complete User Journey', () => {
     await titleFilter.fill(uniqueMaterialTitle);
     await page.click('button:has-text("Apply Filters")');
     await page.waitForLoadState('networkidle');
-    
+
     const materialCell = page.locator(`td:has-text("${uniqueMaterialTitle}")`).first();
     await expect(materialCell).toBeVisible({ timeout: 10000 });
 
@@ -201,26 +235,28 @@ test.describe('@workflow Complete User Journey', () => {
     // まず現在のフィルターをクリアするために、ページをリロード
     await page.reload();
     await page.waitForLoadState('networkidle');
-    
+
     // 検索フィールドに「forest」を入力
     const titleSearchInput = page.locator('input#titleFilter');
     await titleSearchInput.fill('forest');
-    
+
     // Firefox/WebKitでは入力値が確実に反映されるまで待機
     if (crossBrowser.getBrowserName() === 'firefox' || crossBrowser.getBrowserName() === 'webkit') {
       await page.waitForTimeout(500);
     }
-    
+
     // 検索を実行前に入力値を確認（デバッグ用）
     const inputValue = await titleSearchInput.inputValue();
     if (inputValue !== 'forest') {
-      console.error(`Input value is '${inputValue}' instead of 'forest'. Browser: ${crossBrowser.getBrowserName()}`);
+      console.error(
+        `Input value is '${inputValue}' instead of 'forest'. Browser: ${crossBrowser.getBrowserName()}`,
+      );
     }
-    
+
     // 検索を実行
     await page.click('button:has-text("Apply Filters")');
     await page.waitForLoadState('networkidle');
-    
+
     // URLにクエリパラメータが含まれることを確認
     // 注：実際のURLにはpage=1も含まれる可能性があるため、柔軟なパターンを使用
     await expect(page).toHaveURL(/[?&]title=forest/);
@@ -231,8 +267,10 @@ test.describe('@workflow Complete User Journey', () => {
     // 5. 素材詳細確認（検索フィルターを維持したまま）
     // 作成した素材のタイトルボタンをクリックして詳細モーダルを開く
     await crossBrowser.waitForStability();
-    
-    const materialButtonForDetail = page.locator(`button:has-text("${uniqueMaterialTitle}")`).first();
+
+    const materialButtonForDetail = page
+      .locator(`button:has-text("${uniqueMaterialTitle}")`)
+      .first();
     await expect(materialButtonForDetail).toBeVisible();
     await materialButtonForDetail.click();
 
@@ -241,7 +279,9 @@ test.describe('@workflow Complete User Journey', () => {
 
     // 詳細情報が正しく表示されることを確認
     await expect(page.locator('[role="dialog"]')).toContainText(uniqueMaterialTitle);
-    await expect(page.locator('[role="dialog"]').getByText('Miyazaki Forest Park, Japan')).toBeVisible();
+    await expect(
+      page.locator('[role="dialog"]').getByText('Miyazaki Forest Park, Japan'),
+    ).toBeVisible();
     await expect(page.locator('[role="dialog"]')).toContainText('forest');
     await expect(page.locator('[role="dialog"]')).toContainText('nature');
 
@@ -251,29 +291,29 @@ test.describe('@workflow Complete User Journey', () => {
 
     // 検索をクリア
     await titleSearchInput.clear();
-    await page.click('button:has-text("Apply Filters")')
+    await page.click('button:has-text("Apply Filters")');
     await page.waitForLoadState('networkidle');
     await expect(page).toHaveURL(/\/materials(?:\?.*)?$/);
 
     // 4.5. タグ検索機能をテスト（実装されている場合）
     // タグ検索フィールドに「nature」を入力
     const tagSearchInput = page.locator('input#tagFilter');
-    
+
     // タグ検索フィールドが存在する場合のみテスト
-    if (await tagSearchInput.count() > 0) {
+    if ((await tagSearchInput.count()) > 0) {
       await tagSearchInput.fill('nature');
-      
+
       // 検索を実行
       await page.click('button:has-text("Apply Filters")');
-      
+
       // URLの更新を待機（ブラウザによって遅延がある可能性）
       await crossBrowser.waitForStability();
-      
+
       // URLにクエリパラメータが含まれることを確認
       const currentUrl = page.url();
       if (currentUrl.includes('tag=nature') || currentUrl.includes('tags=nature')) {
         console.log('✅ Tag filter applied successfully');
-        
+
         // 検索結果が正しく表示されることを確認（作成した素材にnatureタグが含まれているため）
         await expect(page.locator(`td:has-text("${uniqueMaterialTitle}")`).first()).toBeVisible();
       } else {
@@ -282,7 +322,7 @@ test.describe('@workflow Complete User Journey', () => {
 
       // タグ検索をクリア
       await tagSearchInput.clear();
-      await page.click('button:has-text("Apply Filters")')
+      await page.click('button:has-text("Apply Filters")');
       await page.waitForLoadState('networkidle');
     } else {
       console.log('ℹ️ Tag search field not found, skipping tag search test');
@@ -290,7 +330,7 @@ test.describe('@workflow Complete User Journey', () => {
 
     // 6. ワークフロー完了確認
     // 作成した素材が一覧にあることを確認するため、再度タイトルフィルターを使用
-    
+
     // Firefoxでは前のフィルター操作の影響が残ることがあるため、
     // ページをリロードしてから検索する
     const currentBrowserName = crossBrowser.getBrowserName();
@@ -299,24 +339,47 @@ test.describe('@workflow Complete User Journey', () => {
       await page.reload();
       await page.waitForLoadState('networkidle');
       await page.waitForTimeout(1000);
-      
+
       // titleSearchInputを再取得
       const freshTitleSearchInput = page.locator('input#titleFilter');
       await freshTitleSearchInput.fill(uniqueMaterialTitle);
       await page.click('button:has-text("Apply Filters")');
       await page.waitForLoadState('networkidle');
-      
+
       // Firefoxでは追加の待機
       await page.waitForTimeout(2000);
     } else {
       await titleSearchInput.fill(uniqueMaterialTitle);
       await page.click('button:has-text("Apply Filters")');
       await page.waitForLoadState('networkidle');
+
+      // WebKitでは追加の待機とリロードが必要な場合がある
+      const browserName = page.context().browser()?.browserType().name() || 'unknown';
+      if (browserName === 'webkit') {
+        await page.waitForTimeout(2000);
+
+        // 素材が見つからない場合は、ページをリロードしてもう一度検索
+        const materialVisible = await page
+          .locator(`td:has-text("${uniqueMaterialTitle}")`)
+          .first()
+          .isVisible();
+        if (!materialVisible) {
+          console.log('WebKit: Material not visible, reloading page and searching again...');
+          await page.reload();
+          await page.waitForLoadState('networkidle');
+          await titleSearchInput.fill(uniqueMaterialTitle);
+          await page.click('button:has-text("Apply Filters")');
+          await page.waitForLoadState('networkidle');
+          await page.waitForTimeout(1000);
+        }
+      }
     }
-    
+
     // 素材が表示されることを最終確認（タイムアウトを延長）
-    await expect(page.locator(`td:has-text("${uniqueMaterialTitle}")`).first()).toBeVisible({ timeout: 15000 });
-    
+    await expect(page.locator(`td:has-text("${uniqueMaterialTitle}")`).first()).toBeVisible({
+      timeout: 30000,
+    });
+
     console.log('✅ Complete user journey test passed successfully!');
   });
 
@@ -335,7 +398,7 @@ test.describe('@workflow Complete User Journey', () => {
       const titleButton = firstRow.locator('td').first().locator('button');
       const materialTitle = await titleButton.textContent();
       await titleButton.click();
-      
+
       // 詳細モーダルが開くことを確認
       await crossBrowser.waitForModalOpen();
 
@@ -345,8 +408,11 @@ test.describe('@workflow Complete User Journey', () => {
       }
 
       // 編集ボタンがあるかを確認（将来の機能拡張のため）
-      const editButtonExists = await page.locator('[role="dialog"] button:has-text("Edit")').count() > 0;
-      console.log(editButtonExists ? '✅ Edit button found in modal' : 'ℹ️ Edit button not yet implemented');
+      const editButtonExists =
+        (await page.locator('[role="dialog"] button:has-text("Edit")').count()) > 0;
+      console.log(
+        editButtonExists ? '✅ Edit button found in modal' : 'ℹ️ Edit button not yet implemented',
+      );
 
       // モーダルを閉じる
       await page.keyboard.press('Escape');
@@ -354,14 +420,14 @@ test.describe('@workflow Complete User Journey', () => {
 
       // 検索フィルタリングのテスト
       const titleSearchInput = page.locator('input#titleFilter');
-      
+
       // タイトル検索語を入力
       await titleSearchInput.fill('forest');
       await page.click('button:has-text("Apply Filters")');
-      
+
       // URLが更新されることを確認（pageパラメータも含まれる可能性がある）
       await expect(page).toHaveURL(/[\?&]title=forest/);
-      
+
       // 検索をクリア
       await titleSearchInput.clear();
       await page.click('button:has-text("Apply Filters")');

--- a/e2e/tests/workflows/data-integrity-flow.spec.ts
+++ b/e2e/tests/workflows/data-integrity-flow.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '../../fixtures/test-fixtures';
-import { NavigationHelper, FormHelper, ModalHelper, TableHelper, CrossBrowserHelper } from '../../helpers';
+import {
+  NavigationHelper,
+  FormHelper,
+  ModalHelper,
+  TableHelper,
+  CrossBrowserHelper,
+} from '../../helpers';
+import * as path from 'path';
 
 test.describe.configure({ mode: 'serial' }); // ワークフローテストは順次実行
 test.describe('@workflow Data Integrity Workflow', () => {
@@ -42,27 +49,32 @@ test.describe('@workflow Data Integrity Workflow', () => {
     await modal.waitForClose();
 
     // 機材が正常に追加されたことを確認
-    await expect(page.locator(`td:has-text("${uniqueEquipmentName}")`)).toBeVisible({ timeout: 10000 });
+    await expect(page.locator(`td:has-text("${uniqueEquipmentName}")`)).toBeVisible({
+      timeout: 10000,
+    });
 
     // 3. 新しい機材を使用した素材を作成
     await navigation.goToNewMaterialPage();
     await expect(page.locator('h1')).toHaveText('New Material');
 
     await form.fillByLabel('Title', uniqueMaterialTitle);
-    await form.fillTextareaByLabel('Memo', 'Material for testing data integrity between master and materials');
-    
+    await form.fillTextareaByLabel(
+      'Memo',
+      'Material for testing data integrity between master and materials',
+    );
+
     // 録音日時を設定
     const now = new Date();
     const dateTimeString = now.toISOString().slice(0, 16);
     await form.fillByLabel('Recorded At', dateTimeString);
-    
+
     // 位置情報を入力
     await form.fillByLabel('Latitude', '35.6762');
     await form.fillByLabel('Longitude', '139.6503');
     await form.fillByLabel('Location Name (Optional)', 'Test Studio');
-    
+
     // テスト用音声ファイルをアップロード
-    const testAudioPath = require('path').join(process.cwd(), 'e2e', 'fixtures', 'test-audio.wav');
+    const testAudioPath = path.join(process.cwd(), 'e2e', 'fixtures', 'test-audio.wav');
     await page.locator('input[type="file"]').setInputFiles(testAudioPath);
 
     // 新しく作成した機材を選択（実装されている場合）
@@ -73,11 +85,11 @@ test.describe('@workflow Data Integrity Workflow', () => {
     await form.fillByLabel('Sample Rate (Hz)', '44100');
     await form.fillByLabel('Bit Depth', '16');
     await form.fillByLabel('File Format', 'WAV');
-    
+
     // 素材を保存
     await page.click('button[type="submit"]:has-text("Save Material")');
     await page.waitForURL('/materials', { timeout: 15000 });
-    
+
     // WebKitでは追加の待機が必要
     const browserName = page.context().browser()?.browserType().name() || 'unknown';
     if (browserName === 'webkit' || browserName === 'firefox') {
@@ -86,18 +98,27 @@ test.describe('@workflow Data Integrity Workflow', () => {
       await page.reload();
       await page.waitForLoadState('networkidle');
     }
-    
+
     // タイトルフィルターを使用して作成した素材を検索
     const titleFilter = page.locator('input#titleFilter');
     await titleFilter.fill(uniqueMaterialTitle);
     await page.click('button:has-text("Apply Filters")');
     await page.waitForLoadState('networkidle');
-    
-    await expect(page.locator(`td:has-text("${uniqueMaterialTitle}")`)).toBeVisible({ timeout: 10000 });
+
+    await expect(page.locator(`td:has-text("${uniqueMaterialTitle}")`)).toBeVisible({
+      timeout: 10000,
+    });
 
     // 4. 素材詳細で機材情報が正しく関連付けられていることを確認
     await page.locator(`button:has-text("${uniqueMaterialTitle}")`).click();
-    await crossBrowser.waitForModalOpen();
+
+    // Firefoxでは特別な待機処理が必要
+    if (browserName === 'firefox') {
+      await page.waitForTimeout(1000);
+      await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 20000 });
+    } else {
+      await crossBrowser.waitForModalOpen();
+    }
 
     // 位置情報が正しく表示されることを確認
     await expect(page.locator('[role="dialog"]').getByText('Test Studio')).toBeVisible();
@@ -109,36 +130,33 @@ test.describe('@workflow Data Integrity Workflow', () => {
 
     // 5. 機材を編集して素材への影響を確認
     await navigation.goToEquipmentMasterPage();
-    
+
     // ページが完全に読み込まれるまで待機
     await page.waitForLoadState('networkidle');
-    
+
     // Firefoxでは追加の待機が必要
     if (browserName === 'firefox') {
       await page.waitForTimeout(1000);
     }
-    
+
     // 作成した機材を編集
     const testEquipmentRow = page.locator(`tbody tr:has(td:has-text("${uniqueEquipmentName}"))`);
     await expect(testEquipmentRow).toBeVisible({ timeout: 10000 });
-    
+
     // メニューボタンを待機して表示を確認
     const menuButton = testEquipmentRow.locator('button:has(.sr-only:text("Open menu"))');
     await expect(menuButton).toBeVisible({ timeout: 5000 });
     await menuButton.click();
-    
+
     // メニューアイテムが表示されるまで待機
     await page.waitForSelector('[role="menuitem"]:has-text("Edit")', { state: 'visible' });
     await page.click('[role="menuitem"]:has-text("Edit")');
 
     await crossBrowser.waitForModalOpen();
-    
+
     // 機材名を変更（クロスブラウザ対応）
     const updatedEquipmentName = `Updated Data Integrity Equipment ${timestamp}`;
-    await crossBrowser.fillInputSafely(
-      '[role="dialog"] input[name="name"]',
-      updatedEquipmentName
-    );
+    await crossBrowser.fillInputSafely('[role="dialog"] input[name="name"]', updatedEquipmentName);
 
     await modal.clickButton('Save');
     await crossBrowser.waitForModalClose();
@@ -148,21 +166,23 @@ test.describe('@workflow Data Integrity Workflow', () => {
 
     // 6. 素材詳細で更新された機材名が反映されていることを確認
     await navigation.goToMaterialsPage();
-    
+
     // WebKitとFirefoxでは素材一覧ページに戻った時にフィルターがクリアされる可能性があるため、再度検索
     if (browserName === 'webkit' || browserName === 'firefox') {
       const titleFilter2 = page.locator('input#titleFilter');
       await titleFilter2.fill(uniqueMaterialTitle);
       await page.click('button:has-text("Apply Filters")');
       await page.waitForLoadState('networkidle');
-      await expect(page.locator(`td:has-text("${uniqueMaterialTitle}")`)).toBeVisible({ timeout: 10000 });
-      
+      await expect(page.locator(`td:has-text("${uniqueMaterialTitle}")`)).toBeVisible({
+        timeout: 10000,
+      });
+
       // Firefoxでは追加の待機が必要
       if (browserName === 'firefox') {
         await page.waitForTimeout(500);
       }
     }
-    
+
     // より安定したセレクタで素材を選択
     const materialRow = page.locator(`tbody tr:has-text("${uniqueMaterialTitle}")`);
     await expect(materialRow).toBeVisible({ timeout: 10000 });
@@ -190,7 +210,7 @@ test.describe('@workflow Data Integrity Workflow', () => {
     const firstRow = page.locator('tbody tr').first();
     const materialCountCell = await table.getCellInRow(firstRow, 2); // Material Count列
     expect(materialCountCell).toBeTruthy();
-    
+
     console.log(`🏷️ Found ${tagCount} tags with material counts`);
 
     // 2. 新しい素材を作成してタグ情報を追加
@@ -201,17 +221,17 @@ test.describe('@workflow Data Integrity Workflow', () => {
     const uniqueTagTestTitle = `Tag Consistency Test ${tagTestTimestamp}`;
     await form.fillByLabel('Title', uniqueTagTestTitle);
     await form.fillTextareaByLabel('Memo', 'Testing tag consistency across the system');
-    
+
     const now = new Date();
     const dateTimeString = now.toISOString().slice(0, 16);
     await form.fillByLabel('Recorded At', dateTimeString);
-    
+
     await form.fillByLabel('Latitude', '35.6762');
     await form.fillByLabel('Longitude', '139.6503');
     await form.fillByLabel('Location Name (Optional)', 'Test Location');
-    
+
     // テスト用音声ファイルをアップロード
-    const testAudioPath2 = require('path').join(process.cwd(), 'e2e', 'fixtures', 'test-audio.wav');
+    const testAudioPath2 = path.join(process.cwd(), 'e2e', 'fixtures', 'test-audio.wav');
     await page.locator('input[type="file"]').setInputFiles(testAudioPath2);
 
     // 複数のタグを追加（特殊な構造のため、id属性を使用）
@@ -219,18 +239,18 @@ test.describe('@workflow Data Integrity Workflow', () => {
     await form.fillByLabel('Sample Rate (Hz)', '48000');
     await form.fillByLabel('Bit Depth', '24');
     await form.fillByLabel('File Format', 'WAV');
-    
+
     // 素材を保存（クロスブラウザ対応）
     // Server Actionを使用しているため、ダイアログは表示されない
     await crossBrowser.submitFormWithDialog(
       'button[type="submit"]:has-text("Save Material")',
       undefined, // ダイアログメッセージなし
-      '/materials' // ナビゲーション先
+      '/materials', // ナビゲーション先
     );
-    
+
     // ページが完全に読み込まれるまで待機
     await page.waitForLoadState('networkidle');
-    
+
     // Firefox/WebKitでは特別な処理が必要
     const browserName = page.context().browser()?.browserType().name() || 'unknown';
     if (browserName === 'firefox' || browserName === 'webkit') {
@@ -240,7 +260,7 @@ test.describe('@workflow Data Integrity Workflow', () => {
       await page.click('button:has-text("Apply Filters")');
       await page.waitForLoadState('networkidle');
     }
-    
+
     await crossBrowser.waitForElementVisible(`td:has-text("${uniqueTagTestTitle}")`);
 
     // 3. 素材詳細でタグが正しく表示されることを確認
@@ -248,27 +268,27 @@ test.describe('@workflow Data Integrity Workflow', () => {
     if (browserName === 'firefox') {
       await page.waitForTimeout(1000);
     }
-    
+
     // ボタンを確実に取得してクリック
     const materialButton = page.locator(`button:has-text("${uniqueTagTestTitle}")`);
     await expect(materialButton).toBeVisible({ timeout: 5000 });
-    
+
     // Firefoxでは scrollIntoViewIfNeeded が不安定なので使わない
     if (browserName !== 'firefox') {
       try {
         await materialButton.scrollIntoViewIfNeeded();
-      } catch (e) {
+      } catch {
         console.log('ScrollIntoView failed, continuing without scroll');
       }
     }
-    
+
     await materialButton.click();
-    
+
     // Firefoxでは長めのタイムアウトを設定
     if (browserName === 'firefox') {
       await page.waitForTimeout(500);
     }
-    
+
     await crossBrowser.waitForModalOpen();
 
     // タグが表示されることを確認（一部が含まれていることを確認）
@@ -283,11 +303,11 @@ test.describe('@workflow Data Integrity Workflow', () => {
     // タグ検索フィールドを探す
     // MaterialsPageの実装に合わせて正しいセレクターを使用
     const tagSearchInput = page.locator('input#tagFilter');
-    
-    if (await tagSearchInput.count() > 0) {
+
+    if ((await tagSearchInput.count()) > 0) {
       await tagSearchInput.fill('consistency-test');
       await page.click('button:has-text("Apply Filters")');
-      
+
       // URLが更新されることを確認（tagパラメータ）
       await expect(page).toHaveURL(/\?.*tag=consistency-test/);
 
@@ -313,17 +333,17 @@ test.describe('@workflow Data Integrity Workflow', () => {
     const uniqueMaterialTitle = `CRUD Test Material ${Date.now()}`;
     await form.fillByLabel('Title', uniqueMaterialTitle);
     await form.fillTextareaByLabel('Memo', 'Material for testing full CRUD operations');
-    
+
     const originalTime = new Date();
     const originalTimeString = originalTime.toISOString().slice(0, 16);
     await form.fillByLabel('Recorded At', originalTimeString);
-    
+
     await form.fillByLabel('Latitude', '35.6762');
     await form.fillByLabel('Longitude', '139.6503');
     await form.fillByLabel('Location Name (Optional)', 'CRUD Test Location');
-    
+
     // テスト用音声ファイルをアップロード
-    const testAudioPath3 = require('path').join(process.cwd(), 'e2e', 'fixtures', 'test-audio.wav');
+    const testAudioPath3 = path.join(process.cwd(), 'e2e', 'fixtures', 'test-audio.wav');
     await page.locator('input[type="file"]').setInputFiles(testAudioPath3);
 
     // タグを追加（特殊な構造のため、id属性を使用）
@@ -331,10 +351,10 @@ test.describe('@workflow Data Integrity Workflow', () => {
     await form.fillByLabel('Sample Rate (Hz)', '44100');
     await form.fillByLabel('Bit Depth', '16');
     await form.fillByLabel('File Format', 'WAV');
-    
+
     await page.click('button[type="submit"]:has-text("Save Material")');
     await page.waitForURL('/materials', { timeout: 15000 });
-    
+
     // WebKitでは追加の待機が必要
     const browserName = page.context().browser()?.browserType().name() || 'unknown';
     if (browserName === 'webkit' || browserName === 'firefox') {
@@ -343,24 +363,35 @@ test.describe('@workflow Data Integrity Workflow', () => {
       await page.reload();
       await page.waitForLoadState('networkidle');
     }
-    
+
     // タイトルフィルターを使用して作成した素材を検索
     const titleFilter2 = page.locator('input#titleFilter');
     await titleFilter2.fill(uniqueMaterialTitle);
     await page.click('button:has-text("Apply Filters")');
     await page.waitForLoadState('networkidle');
-    
-    await expect(page.locator(`td:has-text("${uniqueMaterialTitle}")`)).toBeVisible({ timeout: 10000 });
+
+    await expect(page.locator(`td:has-text("${uniqueMaterialTitle}")`)).toBeVisible({
+      timeout: 10000,
+    });
 
     // 2. 読み取り (Read)
     await page.locator(`button:has-text("${uniqueMaterialTitle}")`).click();
-    await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 5000 });
+
+    // Firefoxでは追加の待機が必要な場合がある
+    const currentBrowserName = page.context().browser()?.browserType().name() || 'unknown';
+    if (currentBrowserName === 'firefox') {
+      await page.waitForTimeout(500);
+    }
+
+    await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 10000 });
 
     // 詳細情報が正しく表示されることを確認
     await expect(page.locator('[role="dialog"]').getByText(uniqueMaterialTitle)).toBeVisible();
     // Memoフィールドの内容を確認
-    const memoText = page.locator('[role="dialog"]').getByText('Material for testing full CRUD operations');
-    if (await memoText.count() > 0) {
+    const memoText = page
+      .locator('[role="dialog"]')
+      .getByText('Material for testing full CRUD operations');
+    if ((await memoText.count()) > 0) {
       await expect(memoText).toBeVisible();
     }
     await expect(page.locator('[role="dialog"]').getByText('CRUD Test Location')).toBeVisible();
@@ -368,13 +399,13 @@ test.describe('@workflow Data Integrity Workflow', () => {
 
     // 3. 更新 (Update) - 編集ページへ遷移
     const editButton = page.locator('[role="dialog"] a:has-text("Edit")');
-    if (await editButton.count() > 0) {
+    if ((await editButton.count()) > 0) {
       await editButton.click();
-      
+
       // 編集ページに遷移したことを確認
       await expect(page).toHaveURL(/\/materials\/[^/]+\/edit/);
       await expect(page.locator('h1')).toHaveText('Edit Material');
-      
+
       // タイトルを更新
       const titleInput = page.locator('input#title');
       await titleInput.clear();
@@ -384,28 +415,32 @@ test.describe('@workflow Data Integrity Workflow', () => {
       const memoTextarea = page.locator('textarea#memo');
       await memoTextarea.clear();
       await memoTextarea.fill('Updated memo for CRUD testing');
-      
+
       // alertハンドラーを設定
-      page.once('dialog', async dialog => {
+      page.once('dialog', async (dialog) => {
         expect(dialog.message()).toContain('successfully');
         await dialog.accept();
       });
 
       // 更新を保存
       await page.click('button[type="submit"]:has-text("Save Material")');
-      
+
       // 素材一覧に戻ったことを確認
       await page.waitForURL('/materials');
-      await expect(page.locator('td:has-text("Updated CRUD Test Material")')).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('td:has-text("Updated CRUD Test Material")')).toBeVisible({
+        timeout: 10000,
+      });
 
       // 更新された内容を詳細で確認
       await page.locator('button:has-text("Updated CRUD Test Material")').click();
       await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 5000 });
-      const updatedMemoText = page.locator('[role="dialog"]').getByText('Updated memo for CRUD testing');
-      if (await updatedMemoText.count() > 0) {
+      const updatedMemoText = page
+        .locator('[role="dialog"]')
+        .getByText('Updated memo for CRUD testing');
+      if ((await updatedMemoText.count()) > 0) {
         await expect(updatedMemoText).toBeVisible();
       }
-      
+
       await page.keyboard.press('Escape');
       await expect(page.locator('[role="dialog"]')).not.toBeVisible();
     } else {
@@ -414,23 +449,33 @@ test.describe('@workflow Data Integrity Workflow', () => {
     }
 
     // Firefoxではモーダルが完全に閉じるまで追加の待機が必要
-    const currentBrowserName = page.context().browser()?.browserType().name() || 'unknown';
     if (currentBrowserName === 'firefox') {
       await page.waitForTimeout(1000);
     }
-    
+
     // モーダルが確実に閉じていることを確認
     await expect(page.locator('[role="dialog"]')).not.toBeVisible({ timeout: 5000 });
 
     // 4. 削除 (Delete)
-    await page.locator(`button:has-text("Updated ${uniqueMaterialTitle}"), button:has-text("${uniqueMaterialTitle}")`).first().click();
-    await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 5000 });
+    await page
+      .locator(
+        `button:has-text("Updated ${uniqueMaterialTitle}"), button:has-text("${uniqueMaterialTitle}")`,
+      )
+      .first()
+      .click();
+
+    // Firefoxでは追加の待機が必要な場合がある
+    if (currentBrowserName === 'firefox') {
+      await page.waitForTimeout(500);
+    }
+
+    await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 10000 });
 
     // 削除ボタンをクリック
     const deleteButton = page.locator('[role="dialog"] button:has-text("Delete")');
-    if (await deleteButton.count() > 0) {
+    if ((await deleteButton.count()) > 0) {
       // ダイアログハンドラーを設定
-      page.on('dialog', async dialog => {
+      page.on('dialog', async (dialog) => {
         await dialog.accept();
       });
 
@@ -438,14 +483,16 @@ test.describe('@workflow Data Integrity Workflow', () => {
 
       // 削除確認ダイアログが表示される可能性があるので待機
       await page.waitForTimeout(1000);
-      
+
       // URLが変わるか、モーダルが閉じるのを待つ
       try {
         // 素材一覧ページに戻った場合
         await page.waitForURL('/materials', { timeout: 5000 });
         // 削除された素材が表示されないことを確認
-        await expect(page.locator(`td:has-text("${uniqueMaterialTitle}")`).first()).not.toBeVisible({ timeout: 5000 });
-      } catch (e) {
+        await expect(page.locator(`td:has-text("${uniqueMaterialTitle}")`).first()).not.toBeVisible(
+          { timeout: 5000 },
+        );
+      } catch {
         // まだモーダルが開いている場合（削除が実装されていない、または失敗）
         const isModalVisible = await page.locator('[role="dialog"]').isVisible();
         if (isModalVisible) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,12 +60,15 @@
         "cross-env": "^7.0.3",
         "eslint": "^9",
         "eslint-config-next": "15.3.3",
+        "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-fetch-mock": "^3.0.3",
         "jest-mock-extended": "^4.0.0-beta1",
+        "lint-staged": "^16.1.0",
         "playwright": "^1.52.0",
         "postcss": "^8",
+        "prettier": "^3.5.3",
         "prisma": "^6.8.2",
         "tailwindcss": "^3.4.17",
         "ts-jest": "^29.3.4",
@@ -7384,6 +7387,93 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -7483,6 +7573,13 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -8033,6 +8130,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -8746,6 +8856,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -9132,6 +9249,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -9496,6 +9626,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -11477,6 +11623,160 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.0.tgz",
+      "integrity": "sha512-HkpQh69XHxgCjObjejBT3s2ILwNjFx8M3nw+tJ/ssBauDlIpkx2RpqWSi1fBgkXLSSXnbR3iEq1NkVtpvV+FLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0",
+        "debug": "^4.4.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.3.3",
+        "micromatch": "^4.0.8",
+        "nano-spawn": "^1.0.2",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.8.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -11543,6 +11843,160 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+      "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+      "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -11714,6 +12168,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -11802,6 +12269,19 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nano-spawn": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.2.tgz",
+      "integrity": "sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
     "node_modules/nanoid": {
@@ -12415,6 +12895,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -12710,6 +13203,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -13276,6 +13785,52 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -13285,6 +13840,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -13736,6 +14298,49 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13829,6 +14434,16 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-length": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "e2e:chrome": "npm run e2e -- --project=chromium",
     "e2e:firefox": "npm run e2e -- --project=firefox",
     "e2e:webkit": "npm run e2e -- --project=webkit",
-    "e2e:cross-browser": "npm run e2e -- --project=chromium --project=firefox"
+    "e2e:cross-browser": "npm run e2e -- --project=chromium --project=firefox",
+    "e2e:repeat": "tsx scripts/test-e2e-repeatedly.ts",
+    "prepare": "husky"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
@@ -62,6 +64,15 @@
     "wavesurfer.js": "^7.9.5",
     "zod": "^3.25.46"
   },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{css,md,json}": [
+      "prettier --write"
+    ]
+  },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",
     "@babel/preset-react": "^7.27.1",
@@ -83,12 +94,15 @@
     "cross-env": "^7.0.3",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-fetch-mock": "^3.0.3",
     "jest-mock-extended": "^4.0.0-beta1",
+    "lint-staged": "^16.1.0",
     "playwright": "^1.52.0",
     "postcss": "^8",
+    "prettier": "^3.5.3",
     "prisma": "^6.8.2",
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29.3.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,17 +22,20 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : 5, // 並列度を5に拡張して安定性を確保
+  workers: process.env.CI ? 1 : 3, // 並列度を3に減らして安定性を向上
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI 
+  reporter: process.env.CI
     ? [['list'], ['json', { outputFile: 'test-results/results.json' }]]
     : [
-        ['html', { 
-          open: 'never',  // Changed from 'always' to prevent auto-opening
-          outputFolder: 'playwright-report'
-        }],
+        [
+          'html',
+          {
+            open: 'never', // Changed from 'always' to prevent auto-opening
+            outputFolder: 'playwright-report',
+          },
+        ],
         ['json', { outputFile: 'test-results/results.json' }],
-        ['list']
+        ['list'],
       ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
@@ -47,7 +50,7 @@ export default defineConfig({
   },
 
   /* Timeout configurations */
-  timeout: 60 * 1000, // 60 seconds per test
+  timeout: 90 * 1000, // 90 seconds per test
   expect: {
     timeout: 10 * 1000, // 10 seconds for expect assertions
   },

--- a/scripts/test-e2e-repeatedly.ts
+++ b/scripts/test-e2e-repeatedly.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env tsx
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const MAX_RUNS = 10;
+const LOG_DIR = path.join(process.cwd(), 'e2e-test-logs');
+
+// ログディレクトリを作成
+if (!fs.existsSync(LOG_DIR)) {
+  fs.mkdirSync(LOG_DIR, { recursive: true });
+}
+
+interface TestResult {
+  run: number;
+  success: boolean;
+  duration: number;
+  failedTests: string[];
+  output: string;
+}
+
+const results: TestResult[] = [];
+
+async function runE2ETests(runNumber: number): Promise<TestResult> {
+  console.log(`\n🔄 実行 ${runNumber}/${MAX_RUNS} 開始...`);
+  const startTime = Date.now();
+
+  return new Promise((resolve) => {
+    const logFile = path.join(LOG_DIR, `run-${runNumber}.log`);
+    const logStream = fs.createWriteStream(logFile);
+
+    let output = '';
+    const failedTests: string[] = [];
+
+    const process = spawn('npm', ['run', 'e2e'], {
+      stdio: ['inherit', 'pipe', 'pipe'],
+      shell: true,
+    });
+
+    const captureOutput = (data: Buffer) => {
+      const text = data.toString();
+      output += text;
+      logStream.write(text);
+
+      // 失敗したテストを抽出
+      const failureMatch = text.match(/✘.*?\[(.*?)\].*?›\s*(.*?)$/gm);
+      if (failureMatch) {
+        failureMatch.forEach((match) => {
+          const testMatch = match.match(/\[(.*?)\].*?›\s*(.*)$/);
+          if (testMatch) {
+            failedTests.push(`[${testMatch[1]}] ${testMatch[2].trim()}`);
+          }
+        });
+      }
+    };
+
+    process.stdout.on('data', captureOutput);
+    process.stderr.on('data', captureOutput);
+
+    process.on('close', (code) => {
+      logStream.end();
+      const duration = Date.now() - startTime;
+      const success = code === 0;
+
+      const result: TestResult = {
+        run: runNumber,
+        success,
+        duration,
+        failedTests: [...new Set(failedTests)], // 重複を削除
+        output,
+      };
+
+      results.push(result);
+
+      console.log(
+        `✅ 実行 ${runNumber} 完了: ${success ? '成功' : '失敗'} (${(duration / 1000).toFixed(1)}秒)`,
+      );
+      if (!success) {
+        console.log(`  失敗したテスト数: ${result.failedTests.length}`);
+        result.failedTests.forEach((test) => {
+          console.log(`    - ${test}`);
+        });
+      }
+
+      resolve(result);
+    });
+  });
+}
+
+async function analyzeResults() {
+  console.log('\n📊 === 分析結果 ===\n');
+
+  const successCount = results.filter((r) => r.success).length;
+  const failureCount = results.filter((r) => !r.success).length;
+
+  console.log(
+    `成功: ${successCount}/${MAX_RUNS} (${((successCount / MAX_RUNS) * 100).toFixed(1)}%)`,
+  );
+  console.log(
+    `失敗: ${failureCount}/${MAX_RUNS} (${((failureCount / MAX_RUNS) * 100).toFixed(1)}%)`,
+  );
+
+  // 失敗したテストの統計
+  const failureStats: { [key: string]: number } = {};
+  results.forEach((result) => {
+    if (!result.success) {
+      result.failedTests.forEach((test) => {
+        failureStats[test] = (failureStats[test] || 0) + 1;
+      });
+    }
+  });
+
+  if (Object.keys(failureStats).length > 0) {
+    console.log('\n🔴 失敗したテストの頻度:');
+    Object.entries(failureStats)
+      .sort((a, b) => b[1] - a[1])
+      .forEach(([test, count]) => {
+        console.log(`  ${count}回: ${test}`);
+      });
+  }
+
+  // 平均実行時間
+  const avgDuration = results.reduce((sum, r) => sum + r.duration, 0) / results.length;
+  console.log(`\n⏱️  平均実行時間: ${(avgDuration / 1000).toFixed(1)}秒`);
+
+  // 結果をJSONファイルに保存
+  const summaryPath = path.join(LOG_DIR, 'summary.json');
+  fs.writeFileSync(
+    summaryPath,
+    JSON.stringify(
+      {
+        totalRuns: MAX_RUNS,
+        successCount,
+        failureCount,
+        failureStats,
+        avgDuration,
+        results: results.map((r) => ({
+          run: r.run,
+          success: r.success,
+          duration: r.duration,
+          failedTests: r.failedTests,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+
+  console.log(`\n📁 詳細なログは ${LOG_DIR} に保存されました`);
+}
+
+async function main() {
+  console.log(`🚀 E2E テストを ${MAX_RUNS} 回実行します...\n`);
+
+  for (let i = 1; i <= MAX_RUNS; i++) {
+    const result = await runE2ETests(i);
+
+    // 失敗した場合は早期終了
+    if (!result.success) {
+      console.log(`\n❌ 実行 ${i} で失敗が検出されました。残りの実行をスキップします。`);
+      break;
+    }
+  }
+
+  await analyzeResults();
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## 概要
- コミット前に包括的な品質チェックを実行するpre-commitフックを追加しました
- すべてのテストがパスした場合のみコミットが許可されるようになります

## 実装ステップ
1. **Huskyとlint-stagedの導入**
   - Git pre-commitフック管理用のHuskyを追加
   - ステージングされたファイルの自動整形用のlint-stagedを設定
   - Prettierによるコード整形設定を追加

2. **pre-commitフックの設定**
   - ESLintによるリントチェック（自動修正付き）
   - TypeScriptの型チェック
   - ユニットテスト（カバレッジ付き）
   - セキュリティ監査
   - E2Eテスト（全ブラウザ）

3. **E2Eテストの安定性向上**
   - Firefox/WebKitのブラウザ固有のタイミング問題を修正
   - ESLintエラーの修正（ES6インポート、未使用変数）
   - E2Eテストを繰り返し実行するためのスクリプトを追加（`npm run e2e:repeat`）

## 最終成果物
- `.husky/pre-commit`: 包括的な品質チェックを実行するpre-commitフック
- `.prettierrc`: Prettierの設定ファイル
- `scripts/test-e2e-repeatedly.ts`: E2Eテストの繰り返し実行スクリプト
- 修正されたE2Eテストファイル（クロスブラウザ対応）

## 関連issue
- 品質向上のための自動チェック機能の実装

🤖 Generated with [Claude Code](https://claude.ai/code)