### PR TITLE
feat: フィルター機能でEnterキー押下による適用をサポート

### DIFF
--- a/e2e/tests/materials/materials-list.spec.ts
+++ b/e2e/tests/materials/materials-list.spec.ts
@@ -32,7 +32,7 @@ test.describe('@materials @critical Materials List Page', () => {
   test('can navigate to materials list from sidebar', async ({ page }) => {
     // ホームページから開始
     await page.goto('/');
-    
+
     // サイドバーから素材一覧へ移動（実際のサイドバー構造に合わせて修正）
     await page.click('nav a[href="/materials"]');
     await page.waitForLoadState('networkidle');
@@ -58,7 +58,7 @@ test.describe('@materials @critical Materials List Page', () => {
 
     // タイトル検索フィールドに入力
     await page.fill('input#titleFilter', 'Forest');
-    
+
     // 検索ボタンをクリック
     await page.click('button:has-text("Apply Filters")');
 
@@ -77,7 +77,7 @@ test.describe('@materials @critical Materials List Page', () => {
 
     // タグ検索フィールドに入力
     await page.fill('input#tagFilter', 'nature');
-    
+
     // 検索ボタンをクリック
     await page.click('button:has-text("Apply Filters")');
 
@@ -91,13 +91,34 @@ test.describe('@materials @critical Materials List Page', () => {
     await expect(page).toHaveURL(/\/materials(\?page=1)?$/);
   });
 
+  test('can apply filters using Enter key', async ({ page }) => {
+    await navigation.goToMaterialsPage();
+
+    // タイトル検索フィールドに入力してEnterキーを押す
+    await page.fill('input#titleFilter', 'Forest');
+    await page.locator('input#titleFilter').press('Enter');
+
+    // URLパラメータが更新されることを確認
+    await expect(page).toHaveURL(/\?title=Forest/);
+
+    // ページをリロードしてURLパラメータをクリア
+    await navigation.goToMaterialsPage();
+
+    // タグ検索フィールドに入力してEnterキーを押す
+    await page.fill('input#tagFilter', 'nature');
+    await page.locator('input#tagFilter').press('Enter');
+
+    // URLパラメータが更新されることを確認
+    await expect(page).toHaveURL(/\?tag=nature/);
+  });
+
   test('pagination is displayed', async ({ page }) => {
     await navigation.goToMaterialsPage();
 
     // ページネーションコントロールが存在することを確認（実際の実装に合わせて修正）
     // ページネーションは1ページ以上ある場合のみ表示される
     const pageInfo = page.locator('text=/Page \d+ of \d+/');
-    
+
     // ページ情報が存在する場合、ページネーションボタンも確認
     if (await pageInfo.isVisible()) {
       await expect(page.locator('button:has-text("Previous")')).toBeVisible();

--- a/e2e/tests/projects/projects-crud.spec.ts
+++ b/e2e/tests/projects/projects-crud.spec.ts
@@ -44,6 +44,25 @@ test.describe('@projects @smoke Project CRUD Operations', () => {
     await expect(page.getByRole('button', { name: /Sort by/i })).toBeVisible();
   });
 
+  test('can apply filters using Enter key', async ({ page }) => {
+    await page.goto('/projects');
+    await page.waitForLoadState('networkidle');
+
+    // 名前フィルターに入力してEnterキーを押す
+    await page.fill('input#nameFilter', 'Test');
+    await page.locator('input#nameFilter').press('Enter');
+
+    // URLパラメータが更新されることを確認
+    await expect(page).toHaveURL(/\?name=Test/);
+
+    // フィルターをクリアして再度Enterキーを押す
+    await page.fill('input#nameFilter', '');
+    await page.locator('input#nameFilter').press('Enter');
+
+    // URLがクリアされることを確認（page=1パラメータは許容）
+    await expect(page).toHaveURL(/\/projects(\?page=1)?$/);
+  });
+
   test('新規プロジェクトの作成', async ({ page }) => {
     await page.goto('/projects');
 
@@ -253,10 +272,10 @@ test.describe('@projects @smoke Project CRUD Operations', () => {
 
     // 名前順でソート
     await page.getByRole('menuitem', { name: /Name \(A-Z\)/i }).click();
-    
+
     // URLが更新されるまで待機
     await page.waitForURL(/sortBy=name/, { timeout: 5000 });
-    
+
     // URLにソートパラメータが含まれることを確認
     expect(page.url()).toContain('sortBy=name');
     expect(page.url()).toContain('sortOrder=asc');

--- a/src/app/(app)/materials/__tests__/page.test.tsx
+++ b/src/app/(app)/materials/__tests__/page.test.tsx
@@ -583,6 +583,66 @@ describe('MaterialsPage - Improved Tests', () => {
         expect(screen.queryByText('Rain Sound')).not.toBeInTheDocument();
       });
     });
+
+    it('should apply filters when Enter key is pressed in title filter', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: mockMaterials,
+          pagination: { page: 1, limit: 10, totalPages: 1, totalItems: 3 },
+        }),
+      });
+
+      // Act
+      render(<MaterialsPage />);
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(screen.getByText('Forest Recording')).toBeInTheDocument();
+      });
+
+      // Type in title filter and press Enter
+      const titleInput = screen.getByPlaceholderText('Search by title...');
+      await user.type(titleInput, 'Forest');
+      await user.keyboard('{Enter}');
+
+      // Assert - verify URL update was requested without clicking button
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('title=Forest'));
+        expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('page=1'));
+      });
+    });
+
+    it('should apply filters when Enter key is pressed in tag filter', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: mockMaterials,
+          pagination: { page: 1, limit: 10, totalPages: 1, totalItems: 3 },
+        }),
+      });
+
+      // Act
+      render(<MaterialsPage />);
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(screen.getByText('City Ambience')).toBeInTheDocument();
+      });
+
+      // Type in tag filter and press Enter
+      const tagInput = screen.getByPlaceholderText('Search by tag...');
+      await user.type(tagInput, 'Urban');
+      await user.keyboard('{Enter}');
+
+      // Assert - verify URL update was requested without clicking button
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('tag=Urban'));
+        expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('page=1'));
+      });
+    });
   });
 
   describe('Edge Cases', () => {

--- a/src/app/(app)/materials/page.tsx
+++ b/src/app/(app)/materials/page.tsx
@@ -146,6 +146,13 @@ function MaterialsPageContent() {
     router.replace(`${pathname}?${params.toString()}`);
   };
 
+  const handleFilterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleApplyFilters();
+    }
+  };
+
   const handleSortChange = (sortBy: string, sortOrder: string) => {
     const params = new URLSearchParams(searchParams);
     params.set('sortBy', sortBy);
@@ -228,6 +235,7 @@ function MaterialsPageContent() {
               placeholder="Search by title..."
               value={tempTitleFilter}
               onChange={(e) => setTempTitleFilter(e.target.value)}
+              onKeyDown={handleFilterKeyDown}
             />
           </div>
           <div>
@@ -240,6 +248,7 @@ function MaterialsPageContent() {
               placeholder="Search by tag..."
               value={tempTagFilter}
               onChange={(e) => setTempTagFilter(e.target.value)}
+              onKeyDown={handleFilterKeyDown}
             />
           </div>
           <Button onClick={handleApplyFilters} className="md:self-end">

--- a/src/app/(app)/projects/__tests__/page.test.tsx
+++ b/src/app/(app)/projects/__tests__/page.test.tsx
@@ -438,6 +438,36 @@ describe('ProjectsPage', () => {
         expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('page=1'));
       });
     });
+
+    it('should apply filters when Enter key is pressed in name filter', async () => {
+      // Arrange
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: mockProjects,
+          pagination: { page: 1, limit: 12, totalPages: 1, totalItems: 3 },
+        }),
+      });
+
+      // Act
+      render(<ProjectsPage />);
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(screen.getByText('Nature Sounds Collection')).toBeInTheDocument();
+      });
+
+      // Type in name filter and press Enter
+      const nameInput = screen.getByPlaceholderText('Search by project name...');
+      await user.type(nameInput, 'Nature');
+      await user.keyboard('{Enter}');
+
+      // Assert - verify URL update was requested without clicking button
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('name=Nature'));
+        expect(mockReplace).toHaveBeenCalledWith(expect.stringContaining('page=1'));
+      });
+    });
   });
 
   describe('Edge Cases', () => {

--- a/src/app/(app)/projects/page.tsx
+++ b/src/app/(app)/projects/page.tsx
@@ -131,6 +131,13 @@ function ProjectsPageContent() {
     router.replace(`${pathname}?${params.toString()}`);
   };
 
+  const handleFilterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleApplyFilters();
+    }
+  };
+
   const handleSortChange = (sortBy: string, sortOrder: string) => {
     const params = new URLSearchParams(searchParams);
     params.set('sortBy', sortBy);
@@ -200,6 +207,7 @@ function ProjectsPageContent() {
               placeholder="Search by project name..."
               value={tempNameFilter}
               onChange={(e) => setTempNameFilter(e.target.value)}
+              onKeyDown={handleFilterKeyDown}
             />
           </div>
           <Button onClick={handleApplyFilters} className="md:self-end">


### PR DESCRIPTION
## 概要

MaterialsPageとProjectsPageのフィルター入力フィールドにEnterキー対応を追加しました。
これにより、ユーザーは「Apply Filters」ボタンをクリックすることなく、
Enterキーを押すだけでフィルターを適用できるようになりました。

## 実装内容

### 変更したファイル
- `src/app/(app)/materials/page.tsx`: タイトルとタグフィルターでEnterキー対応
- `src/app/(app)/projects/page.tsx`: 名前フィルターでEnterキー対応

### 実装詳細
- 各ページに`handleFilterKeyDown`ハンドラーを追加
- Enterキー（keyCode: 13）を検出して`handleApplyFilters`を呼び出し
- GlobalSearchコンポーネントと同様の実装パターンを採用

## テスト

### ユニットテスト
- ✅ MaterialsPage: タイトルとタグフィルターでEnterキー押下時の動作をテスト
- ✅ ProjectsPage: 名前フィルターでEnterキー押下時の動作をテスト

### E2Eテスト  
- ✅ Materials: タイトルとタグフィルターでEnterキー押下時の動作をテスト
- ✅ Projects: 名前フィルターでEnterキー押下時の動作をテスト

### 品質チェック
- ✅ ESLint: エラーなし（警告1件は既存のもの）
- ✅ TypeScript: 型エラーなし
- ✅ ビルド: 成功
- ✅ セキュリティ監査: 脆弱性なし

## 動作確認方法

1. 素材一覧ページ（/materials）にアクセス
2. タイトルフィルターに検索語を入力してEnterキーを押す
3. フィルターが適用されることを確認
4. タグフィルターでも同様に確認

5. プロジェクト一覧ページ（/projects）にアクセス  
6. 名前フィルターに検索語を入力してEnterキーを押す
7. フィルターが適用されることを確認

## 関連issue

- Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)